### PR TITLE
Fix total equipment value overflow

### DIFF
--- a/src/main/java/equipmentinspector/EquipmentInspectorPanel.java
+++ b/src/main/java/equipmentinspector/EquipmentInspectorPanel.java
@@ -18,7 +18,7 @@ import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import net.runelite.api.Client;
 
@@ -92,7 +92,7 @@ public class EquipmentInspectorPanel extends PluginPanel
         SwingUtilities.invokeLater(() ->
                 {
                     equipmentPanels.removeAll();
-                    AtomicInteger totalItemPrice= new AtomicInteger();
+                    AtomicLong totalItemPrice= new AtomicLong();
                     playerEquipment.forEach((kitType, itemComposition) ->
                     {
                         AsyncBufferedImage itemImage = itemManager.getImage(itemComposition.getId());

--- a/src/main/java/equipmentinspector/ItemPanel.java
+++ b/src/main/java/equipmentinspector/ItemPanel.java
@@ -16,7 +16,7 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import java.text.NumberFormat;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 class ItemPanel extends JPanel
 {
@@ -91,7 +91,7 @@ class ItemPanel extends JPanel
 }
 class TotalPanel extends JPanel {
 
-    TotalPanel(AtomicInteger total) {
+    TotalPanel(AtomicLong total) {
         setBorder(new EmptyBorder(3, 3, 3, 3));
         setBackground(ColorScheme.DARK_GRAY_COLOR);
 


### PR DESCRIPTION
Changing the `AtomicInteger`s to `AtomicLong`s is enough. Closes #10.

![image](https://user-images.githubusercontent.com/45152844/122609804-93c22c00-d04c-11eb-92cd-b2e698c2c488.png)